### PR TITLE
Fix duplicated function call

### DIFF
--- a/dist/simpletabs.js
+++ b/dist/simpletabs.js
@@ -7,16 +7,10 @@
         element: function(element) {
           return this._element = element;
         },
-        updateTab: function(updateHash) {
-          if (updateHash == null) {
-            updateHash = true;
-          }
+        updateTab: function() {
           this.updateTabLink();
           this.updateTabContainer();
           $('body').scrollTop(0);
-          if (updateHash) {
-            return this.updateURLHash();
-          }
         },
         updateTabLink: function() {
           return this._element.parent().addClass('is-active').siblings('.is-active').removeClass('is-active');
@@ -37,7 +31,7 @@
     };
     if ($('[data-tab]').length) {
       $(window).on('load', function() {
-        var hash, tabs, updateHash;
+        var hash, tabs;
         if (window.location.hash !== '') {
           hash = window.location.hash.replace('#', '');
           tabs = new hashTabs();
@@ -46,7 +40,7 @@
         } else {
           tabs = new hashTabs();
           tabs.element($('[data-tab]').first());
-          return tabs.updateTab(updateHash = false);
+          return tabs.updateTab();
         }
       });
       $(window).on('hashchange', function() {
@@ -60,7 +54,7 @@
         var tabs;
         tabs = new hashTabs();
         tabs.element($(this));
-        tabs.updateTab();
+        tabs.updateURLHash();
         return e.preventDefault();
       });
     }

--- a/simpletabs.coffee
+++ b/simpletabs.coffee
@@ -5,12 +5,10 @@ $ ->
     element: (element) ->
       this._element = element
 
-    updateTab: (updateHash=true)->
+    updateTab: ->
       this.updateTabLink()
       this.updateTabContainer()
       $('body').scrollTop(0)
-      if updateHash
-        this.updateURLHash()
 
     updateTabLink: ->
       this._element.parent().addClass('is-active').siblings('.is-active').removeClass('is-active')
@@ -35,7 +33,7 @@ $ ->
       else
         tabs = new hashTabs()
         tabs.element $("[data-tab]").first()
-        tabs.updateTab(updateHash=false)
+        tabs.updateTab()
 
     $(window).on 'hashchange', ->
       hash = window.location.hash.replace("#", "")
@@ -46,5 +44,5 @@ $ ->
     $('[data-tab]').on 'click', (e) ->
       tabs = new hashTabs()
       tabs.element $(this)
-      tabs.updateTab()
+      tabs.updateURLHash()
       e.preventDefault()


### PR DESCRIPTION
A função updateTab está sendo disparada duas vezes: A primeira pelo evento "click" e a segunda pelo evento "hashchange" oriundo da função updateURLHash que está sendo chamada dentro do próprio updateTab.

Para corrigir isso, no evento de "click", chamei o updateURLHash(ao invés do updateTab) disparando o evento "hashchange" que vai chamar o updateTab uma única vez.
